### PR TITLE
ADTRAN canceled co-ops for Summer 2020.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ You can also like our page on [Facebook](https://www.facebook.com/pg/hiring20/) 
 |:-----------------------------------|:------------------:|:-------------------------------------------------------------------|
 |23andMe|❌||
 |Ad Council|❌ ||
+|ADTRAN|❌ |Summer 2020 co-op term canceled. Fall 2020 may also be canceled if full remote does not end by August 2020.|
 |AKQA|❌ ||
 |Alaska Airlines|❌ ||
 |Alexander Group|❌ ||


### PR DESCRIPTION
ADTRAN sent out an email today saying that all co-ops for the Summer 2020 term have been canceled. If the current situation continues into August 2020, then the Fall 2020 term may also be canceled. I am not certain about the state of their summer internships, though it's likely the same situation.