### PR TITLE
Update for Fannnie Mae Summer 2020 Internship

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ You can also like our page on [Facebook](https://www.facebook.com/pg/hiring20/) 
 |EY-Parthenon|✅|| 
 |F5 Networks|✅|Won't be cancelling. Remote or In-person decision by April 17th|
 |Facebook|✅|Considering remote. More details to come.|
+|Fannie Mae|✅|Remote Internship. Program start date remains June 1. Program duration moved to 6 weeks. All internship and full-time offers honored. Reach out to recruiter with questions|
 |FBI|✅|Reports that some internships are getting cancelled.|
 |Fedex|✅|Update by Mid-April|
 |FireEye|✅|Internship program will proceed. Moving to 100% virtual.|


### PR DESCRIPTION
|Fannie Mae|✅|Remote Internship. Program start date remains June 1. Program duration moved to 6 weeks. All internship and full-time offers honored. Reach out to recruiter with questions|

Greetings! Providing an update that the Fannie Mae - Summer 2020 Internship will be entirely virtual; program will run for 6 weeks, start  date remains June 1.

Many thanks for your help @gcreddy42 !